### PR TITLE
Relax redis gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    cb2 (0.0.3)
-      redis (~> 3.1)
+    cb2 (0.0.3.1)
+      redis (>= 3, < 5)
 
 GEM
   remote: http://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     minitest (5.4.3)
     power_assert (0.2.2)
     rake (10.3.2)
-    redis (3.2.0)
+    redis (4.1.3)
     rr (1.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -42,4 +42,4 @@ DEPENDENCIES
   timecop (~> 0.7)
 
 BUNDLED WITH
-   1.11.2
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cb2 (0.0.3.1)
-      redis (>= 3, < 5)
+      redis (>= 3.1, < 5)
 
 GEM
   remote: http://rubygems.org/
@@ -42,4 +42,4 @@ DEPENDENCIES
   timecop (~> 0.7)
 
 BUNDLED WITH
-   1.17.2
+   2.0.1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # CB2
 
-[![Gem version](http://img.shields.io/gem/v/cb2.svg)](https://rubygems.org/gems/cb2)
-[![Build Status](https://travis-ci.org/pedro/cb2.svg?branch=master)](https://travis-ci.org/pedro/cb2)
-
 Implementation of the [circuit breaker pattern](http://martinfowler.com/bliki/CircuitBreaker.html) in Ruby, backed by Redis.
 
 Setup circuit breakers wrapping external service calls, be it HTTP, TCP, etc. When a service becomes unavailable the circuit breaker will open and quickly refuse any additional requests to it. After a specific window the breaker closes again, allowing calls to go through.

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 3.1"
+  s.add_dependency "redis", ">= 3", "< 5"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", ">= 3", "< 5"
+  s.add_dependency "redis", ">= 3.1", "< 5"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"

--- a/lib/cb2/strategies/rolling_window.rb
+++ b/lib/cb2/strategies/rolling_window.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class CB2::RollingWindow
   attr_accessor :service, :duration, :threshold, :reenable_after, :redis
 


### PR DESCRIPTION
This relaxes the redis gem version to allow for v4. Based on the updates, it looks like `Redis.connect` and `Redis#[]` has gone away, which `cb2` does not use.