### PR TITLE
Add Percentage#reset all! and coverage; update spec for Redis 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,31 @@
 PATH
   remote: .
   specs:
-    cb2 (0.0.3.1)
+    cb2 (0.2.0)
       redis (>= 3.1, < 5)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
+    diff-lcs (1.4.4)
     minitest (5.4.3)
     power_assert (0.2.2)
     rake (10.3.2)
-    redis (4.1.3)
+    redis (4.5.1)
     rr (1.1.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
     test-unit (3.0.8)
       power_assert
     timecop (0.7.1)
@@ -37,9 +38,9 @@ DEPENDENCIES
   minitest
   rake (> 0)
   rr (~> 1.1)
-  rspec (~> 3.1)
+  rspec (~> 3.10)
   test-unit
   timecop (~> 0.7)
 
 BUNDLED WITH
-   2.0.1
+   2.2.30

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = "cb2"
   s.email = "pedrobelo@gmail.com"
-  s.version = "0.1.0"
+  s.version = "0.2.0"
   s.summary = "Circuit breaker"
   s.description = "Implementation of the circuit breaker pattern in Ruby"
   s.authors = ["Pedro Belo"]
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redis", ">= 3.1", "< 5"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
-  s.add_development_dependency "rspec",   "~> 3.1"
+  s.add_development_dependency "rspec",   "~> 3.10"
   s.add_development_dependency "timecop", "~> 0.7"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "minitest"

--- a/lib/cb2/strategies/percentage.rb
+++ b/lib/cb2/strategies/percentage.rb
@@ -4,6 +4,11 @@ class CB2::Percentage < CB2::RollingWindow
     @current_count = increment_rolling_window(key("count"))
   end
 
+  def reset_all!
+    @current_count = redis.del(key('count'))
+    super
+  end
+
   private
 
   def should_open?(error_count)

--- a/spec/strategies/percentage_spec.rb
+++ b/spec/strategies/percentage_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe CB2::Percentage do
-  let(:breaker) do
+  subject(:breaker) do
     CB2::Breaker.new(
       strategy:  :percentage,
       duration:  60,
@@ -12,12 +12,58 @@ describe CB2::Percentage do
   let(:strategy) { breaker.strategy }
 
   describe "#error" do
-    before { @t = Time.now }
+    before { strategy.reset_all! }
 
-    it "opens the circuit when we hit the threshold percentage" do
-      5.times { strategy.count }
-      strategy.error
-      assert breaker.open?
+    context 'when we have not received the minimum number of requests' do
+      before do
+        4.times { strategy.count }
+      end
+
+      it 'passes errors up to the application' do
+        assert_raises(RuntimeError) { breaker.run { raise 'error' } }
+      end
+    end
+
+    context 'when we have received the minimum number of requests' do
+      before do
+        5.times { strategy.count }
+      end
+
+      context 'and we make a successful request' do
+        before { breaker.run { "Hello" } }
+
+        it 'leaves the breaker closed' do
+          assert !breaker.open?
+        end
+      end
+
+      context 'when we hit the threshold error percentage' do
+        before { strategy.error }
+
+        it 'opens the breaker' do
+          assert breaker.open?
+        end
+
+        it 'intercepts the original error and raises CB2::BreakerOpen instead' do
+          assert_raises(CB2::BreakerOpen) { breaker.run { raise 'error' } }
+        end
+
+        context 'and then fully reset the breaker' do
+          before(:each) { strategy.reset_all! }
+
+          it 'closes the breaker' do
+            assert !breaker.open?
+          end
+
+          it 'resets the minimum request counter' do
+            5.times { strategy.count }
+            assert !breaker.open?
+
+            strategy.error
+            assert breaker.open?
+          end
+        end
+      end
     end
   end
 end

--- a/spec/strategies/rolling_window_spec.rb
+++ b/spec/strategies/rolling_window_spec.rb
@@ -81,12 +81,26 @@ describe CB2::RollingWindow do
   end
 
   describe "#reset_all!" do
-    it "deletes the keys" do
-      5.times { strategy.error }
-      strategy.reset_all!
-      assert_equal false, redis.exists(strategy.key)
-      assert_equal false, redis.exists(strategy.key('error'))
-      assert_equal false, redis.exists(strategy.key('success'))
+    shared_examples_for "reset_all" do
+      it "deletes the keys" do
+        5.times { strategy.error }
+        strategy.reset_all!
+        assert_equal delete_val, redis.exists(strategy.key)
+        assert_equal delete_val, redis.exists(strategy.key('error'))
+        assert_equal delete_val, redis.exists(strategy.key('success'))
+      end
+    end
+
+    if Redis::VERSION.match /\A[123]\./ then
+      context "for Redis < 4.0" do
+        let(:delete_val) { false }
+        it_behaves_like "reset_all"
+      end
+    else
+      context "for Redis >= 4.0" do
+        let(:delete_val) { 0 }
+        it_behaves_like "reset_all"
+      end
     end
   end
 end


### PR DESCRIPTION
Gusto/danger_zone installs this gem at 0.0.3.2, which never made it into version control. That version added the `reset_all!` method to `CB2::Percentage`, which is included (and slightly modified) here. Test coverage is included.

For verification, you can compare with the `lib/` of our 0.0.3.2 release:
```
source('https://CREDENTIALS@gemstash.zp-int.com/private') do
  gem 'cb2', '0.0.3.2'
end
```
`bundle install` and then `gem unpack cb2`, and compare lib/cb2/strategies/percentage.rb.


---
Additionally, the spec on RollingWindow is updated to play well with Redis 4; it fails at `master` HEAD as of this writing.

NOTE: I have added a minor version bump as part of this delta to indicate that gem consumers should review changes before doing an update. Please let me know if that (& other release steps) should be done as a separate PR/process.